### PR TITLE
Decision Tree service API spec v0.0.2

### DIFF
--- a/gm-decision-tree/decision-tree-service.yaml
+++ b/gm-decision-tree/decision-tree-service.yaml
@@ -181,7 +181,7 @@ components:
           description: Further descriptive text regarding the question
         type:
           type: string
-          enum: [list, multiSelectList, number, textInput, date, dateRange, postcode, nuts]
+          enum: [boolean, list, multiSelectList, number, textInput, date, dateRange, postcode, nuts]
         pattern:
           type: string
           description: Regex pattern for client-side validation of free text entry fields


### PR DESCRIPTION
This has changed a fair bit now, mostly around how the outcome at each step is processed and handling multi / different answer types.  I can bring in the original from the other repo if you'd prefer to see the diff.. thought this might be clearer!

Not precious about the naming of the various new schema types if there are better alternatives.  Summary:

- Removed the unimplemented `get-journey` endpoint
- Replaced the `journey-results` and `next-question` endpoints with a single `/outcome` endpoint that returns an `Outcome` containing a type (question, agreement, support*) and relevant data
- The `Question` type has been expanded and amended to include optional `description` (sub-text), `definedAnswers` and `pattern` attributes.  
- At each step, the client app now only needs to submit the answer values for the current question - never the entire journey - can be one or more UUIDs (for multi-select), a text/numerical value or date/date range) wrapped in the data attribute of a `QuestionAnswers` payload.  Intention is that the system will inspect the current question instance ID, look up the type and evaluate the array of answer values accordingly (including validation).

Happy to discuss and change - I went through a few iterations trying to work out how best to handle the various answer values and came to the conclusion that a simple array of string values was the simplest and most flexible!