### PR TITLE
Feature/sfat 135 updates match gm api

### DIFF
--- a/gm-decision-tree/decision-tree-service.yaml
+++ b/gm-decision-tree/decision-tree-service.yaml
@@ -196,9 +196,6 @@ components:
           type: string
           description: Commercial agreement number
           example: "RM3733"
-        scale:
-          type: boolean
-          description: Whether this agreement is on the SCALE platform
         lots:
           type: array
           uniqueItems: true
@@ -221,6 +218,9 @@ components:
           type: string
           enum: ['fc','da']
           description: Route to market sub-type (Further Competition or Direct Award)
+        scale:
+          type: boolean
+          description: Whether this lot is on the SCALE platform
         url:
           type: string
           description: Jump off link to start procurement / go to marketplace


### PR DESCRIPTION
This should cover all the changes discussed and detailed on SFAT-135 for consistency with the latest GM API, plus:

- Replace `search-journeys` with `get-journey` endpoint.  Search term to GM journey indexing and lookup will be handled by ElasticSearch indexing a PG database table.  This was in place to support the prototype work only.
- Replace the UUID of the first question in Journey with the entire entity..
- Remove `get-journey-question`.  Now the entire first `QuestionDefinition` entity is included in `Journey`, there is no need for this additional endpoint. 
