### PR TITLE
Tweak procurementID data type

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -2965,7 +2965,8 @@ components:
       properties:
         pocurementID:
           type: string
-          format: uuid
+          pattern: '^[0-9]+$'
+          example: 1234
         eventID:
           type: string
           description: OCID for the event

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -2964,13 +2964,9 @@ components:
       type: object
       properties:
         pocurementID:
-          type: string
-          pattern: '^[0-9]+$'
-          example: 1234
+          $ref: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementProjectID
         eventID:
-          type: string
-          description: OCID for the event
-          example: ocds-abc123-00001
+          $ref: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementEventID
         defaultName:
           $ref: '#/components/schemas/DefaultName'
               

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -2964,9 +2964,9 @@ components:
       type: object
       properties:
         pocurementID:
-          $ref: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementProjectID
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementProjectID'
         eventID:
-          $ref: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementEventID
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/ProcurementEventID'
         defaultName:
           $ref: '#/components/schemas/DefaultName'
               


### PR DESCRIPTION
As discussed - removing `uuid` format as this will now be (at least initially) an auto-incrementing integer.