### PR TITLE
As 42 as initial exposure

### DIFF
--- a/agreements/agreements-service.yaml
+++ b/agreements/agreements-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   title: "SCALE Commercial Agreements Service"
-  version: v0.0.6
+  version: v0.0.7
   description: This API allows access to CCS Commercial Agreement data. This is used both to provide information to users and to govern the behaviour of other systems for example 'Buy a Thing' and 'Contract for a Thing', where processes may differ based on the configuration of the underlying Commercial Agreement and Lot.
 #  PLACEHOLDERs - to be uncommented when implemented
   termsOfService: "http://api.crowncommercial.gov.uk/terms/"
@@ -66,7 +66,7 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
 #
-  /agreements/{agreementID}:
+  /agreements/{agreement-id}:
     get:
       summary: Returns details of the specified Commercial Agreement
       description: Returns the definition of the specified Commercial Agreement
@@ -99,7 +99,7 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
 #
-  /agreements/{agreementID}/documents:
+  /agreements/{agreement-id}/documents:
     get:
       summary: Returns details of the specified Commercial Agreement documents
       description: Returns the documents for the specified Commercial Agreement
@@ -134,7 +134,7 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
  # The get-agreement-detail call explicitly omits CPV codes in the initial version. These will be added later if required. As there are potentially thousands of CPV codes it was felt that these would overwhelm the output and management of the underlying data.  Additional calls can be added to provide these if required in a similar way to the '/agreements/{ca-number}/updates' call below.
-  /agreements/{agreementID}/lots:
+  /agreements/{agreement-id}/lots:
     get:
       summary: Returns details of all of the Lots for this Commercial Agreement
       description: Returns data about the Lots, both general information and parameters required to govern the behaviour of applications using this data
@@ -173,7 +173,7 @@ paths:
               schema:
                $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
   #
-  /agreements/{agreementID}/lots/{lotID}:
+  /agreements/{agreement-id}/lots/{lot-id}:
     get:
       summary: Returns details of the specified Lot for this Commercial Agreement
       description: Returns data about the Lot, both general information and parameters required to govern the behaviour of applications using this data
@@ -207,7 +207,7 @@ paths:
               schema:
                 $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
   #
-  /agreements/{agreementID}/lots/{lotID}/suppliers:
+  /agreements/{agreement-id}/lots/{lot-id}/suppliers:
     get:
       summary: Returns details of the suppliers for the specified Lot for this Commercial Agreement
       description: Returns the supplier list for the Lot
@@ -244,7 +244,7 @@ paths:
                 $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/Errors'
 #
 #
-  /agreements/{agreementID}/updates:
+  /agreements/{agreement-id}/updates:
     get:
       summary: Returns any updates added to the Agreement
       description: Returns updates recorded for the specified Commercial Agreement

--- a/agreements/agreements-service.yaml
+++ b/agreements/agreements-service.yaml
@@ -337,6 +337,8 @@ components:
           format: uri
           description: URL of the Agreement detail page on the CCS website
           example: "https://www.crowncommercial.gov.uk/agreements/RM3733"
+        owner:
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OCDS_Standards/CCS-OCDS_Schema.yaml#/components/schemas/Organization'
         contacts:
           type: array
           items:

--- a/agreements/agreements-service.yaml
+++ b/agreements/agreements-service.yaml
@@ -296,9 +296,7 @@ components:
       type: object
       properties:
         number:
-          type: string
-          description: Commercial Agreement Number
-          example: RM3733
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
         name:
           type: string
           description: Commercial Agreement Name
@@ -312,9 +310,7 @@ components:
       type: object
       properties:
         number:
-          type: string
-          description: Commercial Agreement Number
-          example: "RM3733"
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
         name:
           type: string
           description: Commercial Agreement Name
@@ -357,9 +353,7 @@ components:
       type: object
       properties:
         number:
-          type: string
-          description: Lot number
-          example: 1
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
         name:
           type: string
           description: Lot name
@@ -412,13 +406,9 @@ components:
       description: A simple reference to a related Agreement/Lot combination and relationship type
       properties:
         caNumber:
-          type: string
-          description: Commercial Agreement number
-          example: "RM3733"
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
         lotNumber:
-          type: string
-          description: Lot number within the Commercial Agreement
-          example: "6"
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
         relationship:
           type: string
           description: "The type of the relationship in machine readable form"
@@ -437,7 +427,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BuyingMethod"
-        buyingSystemURL:
+        buyingSystemUrl:
           type: string
           format: uri
           description: The URL to use for the system to progress the procurement (e.g. BaT, CaT, other)
@@ -565,9 +555,7 @@ components:
       type: object
       properties:
         number:
-          type: string
-          description: Lot number
-          example: 1
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
         name:
           type: string
           description: Lot name


### PR DESCRIPTION
Changes needed to align with the API standards, to use central definitions for schema objects and to add agreement owner to the get-agreement-detail