### PR TITLE
Update QuestionGroup to match latest template spec

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3388,7 +3388,7 @@ components:
               description: Defines if the user must answer the question to proceed.
               type: boolean
         OCDS:
-          allof:
+          allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OCDS_Standards/CCS-OCDS_Schema.yaml#/components/schemas/RequirementGroup'
             - type: object
               properties:


### PR DESCRIPTION
Based on Daim's updates to the template they are working with (plus existing discrepancies between the two corresponding types). I'll create a corresponding PR to load the updated template into AS database