### PR TITLE
SCC-757 - updates to EventType structure

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: Tenders API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
-  version: 0.1.9
+  version: 0.1.10
 servers:
   - url: http://api.example.com/v1
     description: Optional server description, e.g. Main (production) server
@@ -370,7 +370,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DefineEventType'
+                  $ref: '#/components/schemas/EventType'
         '401':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
         '403':
@@ -734,7 +734,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/DefineEventType'
+                  $ref: '#/components/schemas/EventType'
         '401':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
         '403':
@@ -2986,7 +2986,7 @@ components:
           - DA
           - SL
           
-    EventType:
+    ViewEventType:
       description: >-
         Event type for GETs (read only).
         Generic term for an event put out to the market. There are several types-
@@ -2996,6 +2996,8 @@ components:
           * RFP - Request for Proposal
           * DA  - Direct Award
           * SL  - Short Listing
+          * TBD - To Be Determined
+          
         Note - TBD is not a real event type and must be defined before going to market.
       type: string
       enum:
@@ -3005,6 +3007,18 @@ components:
           - DA
           - SL
           - TBD
+    
+    EventType:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/DefineEventType'
+        description:
+          type: string
+          description: Description of the Event Type
+        preMarketActivity:
+          type: boolean
+          description: If set to 'true' indicates the Event Type is a pre-market activity
         
 #    EventStatus:
 #      description: >-
@@ -3027,7 +3041,7 @@ components:
           example: itt_2468
           description: ID to allow support staff to support this event. 
         eventType:
-          $ref: '#/components/schemas/EventType'
+          $ref: '#/components/schemas/ViewEventType'
           
 
     EventSummary:
@@ -3342,7 +3356,7 @@ components:
           type: string
           example: New name
         eventType:
-          $ref: '#/components/schemas/EventType'
+          $ref: '#/components/schemas/DefineEventType'
 
     EventDetail:
       description: >-

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -2974,17 +2974,17 @@ components:
         Generic term for an event put out to the market. There are several types-
 
           * EOI - Expression of Interest
-          * RFI -  Request for Information
-          * RFP - Request for Proposal
+          * RFI - Request for Information
+          * CA  - Capability Assessment
           * DA  - Direct Award
-          * SL  - Short Listing
+          * FC  - Further Competition
       type: string
       enum:
           - EOI
           - RFI
-          - RFP
+          - CA
           - DA
-          - SL
+          - FC
           
     ViewEventType:
       description: >-
@@ -2992,10 +2992,10 @@ components:
         Generic term for an event put out to the market. There are several types-
 
           * EOI - Expression of Interest
-          * RFI -  Request for Information
-          * RFP - Request for Proposal
+          * RFI - Request for Information
+          * CA  - Capability Assessment
           * DA  - Direct Award
-          * SL  - Short Listing
+          * FC  - Further Competition
           * TBD - To Be Determined
           
         Note - TBD is not a real event type and must be defined before going to market.
@@ -3003,9 +3003,9 @@ components:
       enum:
           - EOI
           - RFI
-          - RFP
+          - CA
           - DA
-          - SL
+          - FC
           - TBD
     
     EventType:


### PR DESCRIPTION
SCC-757 - Updated the existing `EventType` to be called `ViewEventType`. This is effectively the same as the existing `DefineEventType` enum, with an extra `TBD`.

Introduced a new `EventType` schema which is the same as that exposed by the Agreements Service - this will return the `DefineEventType` enum along with description and preMarketActivity indicator