### PR TITLE
SCC-672 - removed uuid format from TeamMember id

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3003,7 +3003,6 @@ components:
         id:  
           type: string
           readOnly: true
-          format: uuid
           description: 'ID of the team member'
           example: 222
         contact:


### PR DESCRIPTION
Tiny change to remove the `uuid` format from TeamMember id (as the data is not a UUID)