### PR TITLE
Pare back PM endpoint response codes to those in use

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -33,7 +33,7 @@ paths:
                   - type: object
                     properties:
                       userAction:
-                        example: created
+                        example: existed
             
         '201':
           description: Success (for object creation). Its information is available in the
@@ -47,7 +47,7 @@ paths:
                   - type: object
                     properties:
                       userAction:
-                        example: existed
+                        example: created
         '400':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/400InvalidRequest'
         '401':
@@ -3742,7 +3742,6 @@ components:
               * created - Supplier user not found in sales platform and was created
               * existed - User existed already in sales platform and was updated
           enum:
-     
             - created
             - existed
         organisationAction:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3724,15 +3724,26 @@ components:
       properties:
         userAction:
           type: string
+          description: |+
+            What action if any was taken for the user:
+              * pending - Buyer user was not found in sales platform and was created in pending state
+              * created - Supplier user not found in sales platform and was created
+              * existed - User existed already in sales platform and was updated
           enum:
+            - pending      
             - created
-            - existed            
+            - existed
         organisationAction:
           type: string
+          description: |+
+            What action if any was taken for the organisation:
+              * created - Supplier org not found in sales platform and was created
+              * existed - Supplier org or Buyer already in sales platform - no action        
+              * pending - Not currently in use
           enum:
             - created
-            - pending
             - existed
+            - pending
         roles:
           type: array
           items:
@@ -3746,10 +3757,15 @@ components:
       properties:
         organisationAction:
           type: string
+          description: |+
+            What action if any was taken for the organisation:
+              * existed - Org existed already in sales platform and was updated (supplier orgs only)
+              * nonRequired - No action taken (buyer orgs only)
+              * pending - Not currently in use
           enum:
-            - created
-            - pending
             - existed
+            - nonRequired
+            - pending
         roles:
           type: array
           items:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -28,7 +28,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegisterUserResponse'
+                allOf:
+                  - $ref: '#/components/schemas/RegisterUserResponse'
+                  - type: object
+                    properties:
+                      userAction:
+                        example: created
+            
         '201':
           description: Success (for object creation). Its information is available in the
             data field at the top level of the response body. The API URL where
@@ -36,7 +42,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RegisterUserResponse'
+                allOf:
+                  - $ref: '#/components/schemas/RegisterUserResponse'
+                  - type: object
+                    properties:
+                      userAction:
+                        example: existed
         '400':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/400InvalidRequest'
         '401':
@@ -94,6 +105,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UpdateOrgResponse'
+
+
         '400':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/400InvalidRequest'
         '401':
@@ -3726,11 +3739,10 @@ components:
           type: string
           description: |+
             What action if any was taken for the user:
-              * pending - Buyer user was not found in sales platform and was created in pending state
               * created - Supplier user not found in sales platform and was created
               * existed - User existed already in sales platform and was updated
           enum:
-            - pending      
+     
             - created
             - existed
         organisationAction:
@@ -3739,7 +3751,7 @@ components:
             What action if any was taken for the organisation:
               * created - Supplier org not found in sales platform and was created
               * existed - Supplier org or Buyer already in sales platform - no action        
-              * pending - Not currently in use
+              * pending - Buyer org not found in sales platform and was created in pending state
           enum:
             - created
             - existed
@@ -3759,13 +3771,16 @@ components:
           type: string
           description: |+
             What action if any was taken for the organisation:
+              * nonRequired - No action taken (buyer orgs cannot currently be updated via this method)
+              * created - Not Currently in use (Orgs cannot currently be created via this method)
               * existed - Org existed already in sales platform and was updated (supplier orgs only)
-              * nonRequired - No action taken (buyer orgs only)
-              * pending - Not currently in use
+              * pending - Not currently in use (Orgs cannot currently be created via this method)
           enum:
-            - existed
             - nonRequired
+            - created
+            - existed
             - pending
+          example: existed
         roles:
           type: array
           items:
@@ -3773,6 +3788,7 @@ components:
             enum:
               - buyer
               - supplier
+            example: supplier
 
   securitySchemes:
     openID:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -28,25 +28,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  userAction:
-                    type: string
-                    enum:
-                      - existed
-                  organisationAction:
-                    type: string
-                    enum:
-                      - created
-                      - pending
-                      - existed
-                  roles:
-                    type: array
-                    items:
-                      type: string
-                      enum:
-                        - buyer
-                        - supplier
+                $ref: '#/components/schemas/RegisterUserResponse'
         '201':
           description: Success (for object creation). Its information is available in the
             data field at the top level of the response body. The API URL where
@@ -63,14 +45,8 @@ paths:
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
         '404':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/404NotFound'
-        '429':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
         '500':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
-        '502':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
-        '504':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/504GatewayTimeout'
         default:
           description: successful operation
       summary: Register user to use Tenders (Jaggaer)
@@ -93,19 +69,15 @@ paths:
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
         '404':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/404NotFound'
-        '429':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
+        '409':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/409Conflict'        
         '500':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
-        '502':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
       security:
         - openID:
             - read
             - write
       summary: Check User registered to use Tenders API (Jaggaer)
-      
-
       
   /tenders/orgs/{org-id}:
     parameters:
@@ -130,14 +102,8 @@ paths:
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
         '404':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/404NotFound'
-        '429':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
         '500':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
-        '502':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
-        '504':
-          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/504GatewayTimeout'
         default:
           description: successful operation
       summary: Update org details in Tenders (Jaggaer)
@@ -3760,6 +3726,7 @@ components:
           type: string
           enum:
             - created
+            - existed            
         organisationAction:
           type: string
           enum:


### PR DESCRIPTION
Also consolidated the `RegisterUserResponse` type for  both `200` and `201` responses on the `PUT`.