### PR TITLE
Include agreementId and lotId pattern for validation in CaT service

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3040,7 +3040,7 @@ components:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
           readOnly: false
-          pattern: '[a-zA-Z0-9 ]+'
+          pattern: '([a-zA-Z0-9]+[ ]*)+'
           maxLength: 20
           
     ExtendCriteria:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3035,12 +3035,13 @@ components:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
           readOnly: false
-          pattern: 'RM[0-9]{4}(\.[0-9]{1,2})?'
+          pattern: 'RM[0-9]{4}([.][0-9]{1,2})?'
         lotId:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
           readOnly: false
-          minLength: 1
+          pattern: '[\w\s]+'
+          maxLength: 20
           
     ExtendCriteria:
       description: >-

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3023,6 +3023,8 @@ components:
         - TEAM_MEMBER
         - PROJECT_OWNER
               
+    # See openapi-generator issue: https://github.com/OpenAPITools/openapi-generator/issues/7342
+    # Hence why we are repeating the validation attributes here, until a fix is issued
     AgreementDetails:
       type: object
       properties:
@@ -3030,10 +3032,12 @@ components:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
           readOnly: false
+          pattern: 'RM[0-9]{4}(.[0-9]{1,2})?'
         lotId:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
           readOnly: false
+          minLength: 1
           
     ExtendCriteria:
       description: >-

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3032,7 +3032,7 @@ components:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/AgreementId'
           readOnly: false
-          pattern: 'RM[0-9]{4}(.[0-9]{1,2})?'
+          pattern: 'RM[0-9]{4}(\.[0-9]{1,2})?'
         lotId:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3027,6 +3027,9 @@ components:
     # Hence why we are repeating the validation attributes here, until a fix is issued
     AgreementDetails:
       type: object
+      required:
+        - agreementId
+        - lotId
       properties:
         agreementId:
           allOf:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3040,7 +3040,7 @@ components:
           allOf:
             - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/LotId'
           readOnly: false
-          pattern: '[\w\s]+'
+          pattern: '[a-zA-Z0-9 ]+'
           maxLength: 20
           
     ExtendCriteria:


### PR DESCRIPTION
- The openapi-generator has an open issue that prevents the validation annotations being applied to generated model classes when they are present on `allOf` ref'd schemas: https://github.com/OpenAPITools/openapi-generator/issues/7342
- This change is a tactical workaround that also tweaks the AgreementId regex to explicitly expect a `.` in the optional second group, i.e. `RM0123.56` (previously was allowing any character)