### PR TITLE
Feature/scat 2303 document upload

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -4007,6 +4007,7 @@ components:
             type: string  
           fileSize:
             type: number
+            format: integer
           description: 
             type: string  
           audience:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3930,7 +3930,7 @@ components:
       type: string
       enum:
         - buyer
-        - supplier
+        - seller
               
     DocumentSummary:
       description: Metadata relating to an attached document

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -1932,11 +1932,7 @@ paths:
                   type: string
                   description: Description of document
                 audience:
-                  type: string
-                  enum:
-                    - buyer
-                    - supplier 
-                  description: Audience for the document - 'buyer' or 'seller'
+                  $ref: '#/components/schemas/DocumentAudienceType'
       responses:
         '200':
           description: ok

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -4006,8 +4006,7 @@ components:
           fileName: 
             type: string  
           fileSize:
-            type: number
-            format: integer
+            type: integer
           description: 
             type: string  
           audience:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -4007,6 +4007,7 @@ components:
             type: string  
           fileSize:
             type: integer
+            format: int64
           description: 
             type: string  
           audience:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -1885,7 +1885,7 @@ paths:
       - $ref: '#/components/parameters/EventParam'
 
     get:
-      description: Get documents attached to an event
+      description: Get summary information of documents attached to an event
       tags:
         - Define Procurement Event
       operationId: getDocuments
@@ -1911,10 +1911,10 @@ paths:
       security:
         - OAuth2:
             - buyer
-      summary: Get Event Documents
+      summary: Get documents attached to an event
       
     put:
-      description: Add/update a document
+      description: Add/update a document attached to an event
       tags:
         - Define Procurement Event
       operationId: updateDocument
@@ -1939,7 +1939,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventSummary'
+                $ref: '#/components/schemas/DocumentSummary'
         '400':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/400InvalidRequest'
         '401':
@@ -1955,7 +1955,7 @@ paths:
       security:
         - OAuth2:
             - buyer
-      summary: Add/Update a document
+      summary: Add/update a document attached to an event
       
   /tenders/projects/{proc-id}/events/{event-id}/documents/{document-id}:
     parameters:
@@ -1964,7 +1964,7 @@ paths:
       - $ref: '#/components/parameters/DocumentParam'
 
     get:
-      description: Download a document
+      description: Download a document attached to an event
       tags:
         - Define Procurement Event
       operationId: getDocument
@@ -1972,13 +1972,16 @@ paths:
         '200':
           description: ok
           content:
-            application/json:
+            application/octet-stream:
               schema:
-                $ref: '#/components/schemas/DocumentSummary'
+                type: string
+                format: binary
         '401':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
         '403':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
+        '404':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/404NotFound'
         '429':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
         '500':
@@ -1988,7 +1991,7 @@ paths:
       security:
         - OAuth2:
             - buyer
-      summary: Get Event Document
+      summary: Download a document attached to an event
       
   /tenders/projects/{proc-id}/events/{event-id}/GotoMarket/options:
     parameters:
@@ -2932,7 +2935,9 @@ components:
       required: true
       description: Document ID
       schema:
-        $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/GenericId'
+        type: string
+        example: YnV5ZXJANzYxMzg0OUBjYXQtamFnZ2Flci1maWxlLXRlc3QtMi50eHQ=
+        readOnly: true
 
 
   schemas:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: Tenders API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
-  version: 0.1.11
+  version: 0.1.12
 servers:
   - url: http://api.example.com/v1
     description: Optional server description, e.g. Main (production) server
@@ -1879,11 +1879,125 @@ paths:
             - buyer
       summary: Update a Procurement Event
       
-  /tenders/projects/{proc-id}/events/{event-id}/GotoMarket/options:
+  /tenders/projects/{proc-id}/events/{event-id}/documents:
     parameters:
       - $ref: '#/components/parameters/ProcurementParam'
       - $ref: '#/components/parameters/EventParam'
 
+    get:
+      description: Get documents attached to an event
+      tags:
+        - Define Procurement Event
+      operationId: getDocuments
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DocumentSummary'
+        '401':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
+        '403':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
+        '429':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
+        '500':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
+        '502':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
+      security:
+        - OAuth2:
+            - buyer
+      summary: Get Event Documents
+      
+    put:
+      description: Add/update a document
+      tags:
+        - Define Procurement Event
+      operationId: updateDocument
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: string
+                  format: binary
+                  description: The document file content
+                description:
+                  type: string
+                  description: Description of document
+                audience:
+                  type: string
+                  enum:
+                    - buyer
+                    - supplier 
+                  description: Audience for the document - 'buyer' or 'seller'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventSummary'
+        '400':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/400InvalidRequest'
+        '401':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
+        '403':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
+        '429':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
+        '500':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
+        '502':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
+      security:
+        - OAuth2:
+            - buyer
+      summary: Add/Update a document
+      
+  /tenders/projects/{proc-id}/events/{event-id}/documents/{document-id}:
+    parameters:
+      - $ref: '#/components/parameters/ProcurementParam'
+      - $ref: '#/components/parameters/EventParam'
+      - $ref: '#/components/parameters/DocumentParam'
+
+    get:
+      description: Download a document
+      tags:
+        - Define Procurement Event
+      operationId: getDocument
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentSummary'
+        '401':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
+        '403':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/403Forbidden'
+        '429':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/429TooManyRequests'
+        '500':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/500InternalServerError'
+        '502':
+          $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/502BadGateway'
+      security:
+        - OAuth2:
+            - buyer
+      summary: Get Event Document
+      
+  /tenders/projects/{proc-id}/events/{event-id}/GotoMarket/options:
+    parameters:
+      - $ref: '#/components/parameters/ProcurementParam'
+      - $ref: '#/components/parameters/EventParam'
 
     get:
       description: Get the options open to go to market
@@ -2808,12 +2922,19 @@ components:
       schema:
         $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/GenericId'
     
-        
     NeedParam:
       name: question-id
       in: path
       required: true
       description: Procurement Need ID
+      schema:
+        $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/GenericId'
+        
+    DocumentParam:
+      name: document-id
+      in: path
+      required: true
+      description: Document ID
       schema:
         $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Schema.yaml#/components/schemas/GenericId'
 
@@ -3802,6 +3923,16 @@ components:
               - buyer
               - supplier
             example: supplier
+            
+    DocumentSummary:
+      description: >-
+        Metadata relating to an attached document
+      type: object
+      properties:
+          filename: 
+            type: string          
+          description: 
+            type: string  
 
   securitySchemes:
     openID:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -1976,6 +1976,71 @@ paths:
               schema:
                 type: string
                 format: binary
+            application/msword:
+              schema:
+                type: string
+                format: binary
+            application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+              schema:
+                type: string
+                format: binary
+            application/vnd.oasis.opendocument.spreadsheet:
+              schema:
+                type: string
+                format: binary
+            application/vnd.oasis.opendocument.text:
+              schema:
+                type: string
+                format: binary
+            application/vnd.ms-powerpoint:
+              schema:
+                type: string
+                format: binary
+            application/vnd.openxmlformats-officedocument.presentationml.presentation:
+              schema:
+                type: string
+                format: binary
+            application/rtf:
+              schema:
+                type: string
+                format: binary
+            application/vnd.ms-excel:
+              schema:
+                type: string
+                format: binary
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                type: string
+                format: binary
+            application/xml:
+              schema:
+                type: string
+                format: binary
+            application/zip:
+              schema:
+                type: string
+                format: binary
+            application/vnd.google-earth.kml+xml application/vnd.google-earth.kmz:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            text/csv:
+              schema:
+                type: string
+                format: binary
+            text/plain:
+              schema:
+                type: string
+                format: binary
+            
         '401':
           $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OpenAPI_Standards/CCS_Standard_API_Responses.yaml#/components/responses/401Unauthorized'
         '403':
@@ -3938,8 +4003,10 @@ components:
       properties:
           id:
             type: string
-          filename: 
-            type: string          
+          fileName: 
+            type: string  
+          fileSize:
+            type: number
           description: 
             type: string  
           audience:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3930,7 +3930,7 @@ components:
       type: string
       enum:
         - buyer
-        - seller
+        - supplier
               
     DocumentSummary:
       description: Metadata relating to an attached document

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3924,15 +3924,25 @@ components:
               - supplier
             example: supplier
             
+    DocumentAudienceType:
+      description: Intended audience for a document
+      type: string
+      enum:
+        - buyer
+        - supplier
+              
     DocumentSummary:
-      description: >-
-        Metadata relating to an attached document
+      description: Metadata relating to an attached document
       type: object
       properties:
+          id:
+            type: string
           filename: 
             type: string          
           description: 
             type: string  
+          audience:
+            $ref: '#/components/schemas/DocumentAudienceType'
 
   securitySchemes:
     openID:


### PR DESCRIPTION
Added the candidate endpoints to `GET` and `PUT` documents at event level.

3 endpoints:

- `GET enders/projects/{proc-id}/events/{event-id}/documents` - returns a summary of all documents at event level, with indication whether they are for buyers or suppliers
- `PUT /tenders/projects/{proc-id}/events/{event-id}/documents` - adds a new document (or updates an existing one if filename is the same)
-  `GET enders/projects/{proc-id}/events/{event-id}/documents/{document-id}`- download a specific document. Note - here wasn't sure of content type given many formats are supported - `application/octet-stream` seemed to be default for this (but not 100% sure)

Not precious about any/all if any better suggestions on approach.

Code is working for the first 2 - but can easily be refactored. Third is in progress trying to get something working.