### PR TITLE
Feature/scat 2639 ade test

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3486,32 +3486,8 @@ components:
             buyerQuestions:
               type: array
               items:
-                allOf:
-                  - $ref: '#/components/schemas/EvalCriteria'
-                  - type: object
-                    properties:
-                      relatesTo:
-                        type: string
-                      relateItems:
-                        type: string
-                      requirementGroups:
-                        type: array
-                        items:
-                          allOf:
-                            - $ref: '#/components/schemas/QuestionGroup'
-                            - type: object
-                              properties:
-                                OCDS:
-                                  type: object
-                                  properties:
-                                    requirements:
-                                      type: array
-                                      items:
-                                        $ref: '#/components/schemas/Question'
-                                
+                $ref: '#/components/schemas/BuyerQuestion'
               description: Defines the questions that the buyer should answer to create the event along with answers given.
-              
-                 
 
     EventDetailOCDS:
       allOf:
@@ -4047,6 +4023,32 @@ components:
           audience:
             $ref: '#/components/schemas/DocumentAudienceType'
 
+    BuyerQuestion:
+      description: Defines a question that the buyer should answer to create the event along with answers given.
+      allOf:
+        - $ref: '#/components/schemas/EvalCriteria'
+        - type: object
+          properties:
+            relatesTo:
+              type: string
+            relateItems:
+              type: string
+            requirementGroups:
+              type: array
+              items:
+                allOf:
+                  - $ref: '#/components/schemas/QuestionGroup'
+                  - type: object
+                    properties:
+                      OCDS:
+                        type: object
+                        properties:
+                          requirements:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/Question'
+                        
+      
   securitySchemes:
     openID:
       type: openIdConnect

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3483,11 +3483,6 @@ components:
               type: string
               format: date-time
               description: Date/time - Event Created
-            buyerQuestions:
-              type: array
-              items:
-                $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
-              description: Defines the questions that the buyer should answer to create the event along with answers given.
 
     EventDetailOCDS:
       allOf:
@@ -3736,6 +3731,11 @@ components:
           $ref: '#/components/schemas/EventDetailNonOCDS'
         OCDS:
           $ref: '#/components/schemas/EventDetailOCDS'
+        buyerQuestions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
+          description: Defines the questions that the buyer should answer to create the event along with answers given.
             
     ProjectTerminationType:
       #allOf:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -4028,13 +4028,10 @@ components:
         - $ref: '#/components/schemas/QuestionGroup'
         - type: object
           properties:
-            OCDS:
-              type: object
-              properties:
-                requirements:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Question'
+            requirements:
+              type: array
+              items:
+                $ref: '#/components/schemas/Question'
     
     BuyerQuestionEvalCriteria:
       description: Defines a question that the buyer should answer to create the event along with answers given.

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3206,7 +3206,7 @@ components:
             $ref: '#/components/schemas/UpdateTeamMemberType'
               
     UpdateTeamMemberType:
-      description:
+      description: >-
         Defines which new permission should be granted to a project Team Member
       type: string
       enum:
@@ -3482,7 +3482,7 @@ components:
             eventCreated:
               type: string
               format: date-time
-              description: Date/time - Event Create
+              description: Date/time - Event Created
             buyerQuestions:
               type: array
               items:
@@ -4035,7 +4035,6 @@ components:
           audience:
             $ref: '#/components/schemas/DocumentAudienceType'
 
-      
   securitySchemes:
     openID:
       type: openIdConnect

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3482,7 +3482,12 @@ components:
             eventCreated:
               type: string
               format: date-time
-              description: Date/time - Event Created
+              description: Date/time - Event Create
+            buyerQuestions:
+              type: array
+              items:
+                $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
+              description: Defines the questions that the buyer should answer to create the event along with answers given.
 
     EventDetailOCDS:
       allOf:
@@ -3731,11 +3736,6 @@ components:
           $ref: '#/components/schemas/EventDetailNonOCDS'
         OCDS:
           $ref: '#/components/schemas/EventDetailOCDS'
-        buyerQuestions:
-          type: array
-          items:
-            $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
-          description: Defines the questions that the buyer should answer to create the event along with answers given.
             
     ProjectTerminationType:
       #allOf:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3486,7 +3486,7 @@ components:
             buyerQuestions:
               type: array
               items:
-                $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
+                $ref: '#/components/schemas/EvalCriteria'
               description: Defines the questions that the buyer should answer to create the event along with answers given.
 
     EventDetailOCDS:
@@ -3792,7 +3792,15 @@ components:
           title: 
             type: string          
           description: 
-            type: string  
+            type: string
+          relatesTo:
+            type: string
+          relateItems:
+            type: string
+          requirementGroups:
+            type: array
+            items:
+              $ref: '#/components/schemas/QuestionGroup'
             
             
     QuestionGroup:
@@ -4026,21 +4034,7 @@ components:
             type: string  
           audience:
             $ref: '#/components/schemas/DocumentAudienceType'
-    
-    BuyerQuestionEvalCriteria:
-      description: Defines a question that the buyer should answer to create the event along with answers given.
-      allOf:
-        - $ref: '#/components/schemas/EvalCriteria'
-        - type: object
-          properties:
-            relatesTo:
-              type: string
-            relateItems:
-              type: string
-            requirementGroups:
-              type: array
-              items:
-                $ref: '#/components/schemas/QuestionGroup'
+
       
   securitySchemes:
     openID:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3486,7 +3486,7 @@ components:
             buyerQuestions:
               type: array
               items:
-                $ref: '#/components/schemas/BuyerQuestion'
+                $ref: '#/components/schemas/BuyerQuestionEvalCriteria'
               description: Defines the questions that the buyer should answer to create the event along with answers given.
 
     EventDetailOCDS:
@@ -4023,7 +4023,20 @@ components:
           audience:
             $ref: '#/components/schemas/DocumentAudienceType'
 
-    BuyerQuestion:
+    BuyerQuestionGroup:
+      allOf:
+        - $ref: '#/components/schemas/QuestionGroup'
+        - type: object
+          properties:
+            OCDS:
+              type: object
+              properties:
+                requirements:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Question'
+    
+    BuyerQuestionEvalCriteria:
       description: Defines a question that the buyer should answer to create the event along with answers given.
       allOf:
         - $ref: '#/components/schemas/EvalCriteria'
@@ -4036,18 +4049,7 @@ components:
             requirementGroups:
               type: array
               items:
-                allOf:
-                  - $ref: '#/components/schemas/QuestionGroup'
-                  - type: object
-                    properties:
-                      OCDS:
-                        type: object
-                        properties:
-                          requirements:
-                            type: array
-                            items:
-                              $ref: '#/components/schemas/Question'
-                        
+                $ref: '#/components/schemas/BuyerQuestionGroup'
       
   securitySchemes:
     openID:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3495,17 +3495,19 @@ components:
                       relateItems:
                         type: string
                       requirementGroups:
-                        allOf:
-                          - $ref: '#/components/schemas/QuestionGroup'
-                          - type: object
-                            properties:
-                              OCDS:
-                                type: object
-                                properties:
-                                  requirements:
-                                    type: array
-                                    items:
-                                      $ref: '#/components/schemas/Question'
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: '#/components/schemas/QuestionGroup'
+                            - type: object
+                              properties:
+                                OCDS:
+                                  type: object
+                                  properties:
+                                    requirements:
+                                      type: array
+                                      items:
+                                        $ref: '#/components/schemas/Question'
                                 
               description: Defines the questions that the buyer should answer to create the event along with answers given.
               

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3206,7 +3206,7 @@ components:
             $ref: '#/components/schemas/UpdateTeamMemberType'
               
     UpdateTeamMemberType:
-      description: >-
+      description:
         Defines which new permission should be granted to a project Team Member
       type: string
       enum:
@@ -3483,7 +3483,32 @@ components:
               type: string
               format: date-time
               description: Date/time - Event Created
-
+            buyerQuestions:
+              type: array
+              items:
+                allOf:
+                  - $ref: '#/components/schemas/EvalCriteria'
+                  - type: object
+                    properties:
+                      relatesTo:
+                        type: string
+                      relateItems:
+                        type: string
+                      requirementGroups:
+                        allOf:
+                          - $ref: '#/components/schemas/QuestionGroup'
+                          - type: object
+                            properties:
+                              OCDS:
+                                type: object
+                                properties:
+                                  requirements:
+                                    type: array
+                                    items:
+                                      $ref: '#/components/schemas/Question'
+                                
+              description: Defines the questions that the buyer should answer to create the event along with answers given.
+              
                  
 
     EventDetailOCDS:
@@ -3812,18 +3837,21 @@ components:
               description: Defines if the user must answer the question to proceed.
               type: boolean
         OCDS:
-          allOf:
-            - $ref: 'https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/CCS_OCDS_Standards/CCS-OCDS_Schema.yaml#/components/schemas/RequirementGroup'
-            - type: object
-              properties:
-                id:
-                  description: 'The identifier for this question group. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.'
-                  readOnly: true
-                description: 
-                  description: A description of this question group.
-                requirements:
-                  deprecated: true
-                  description: Inherited from OCDS RequirementsGroup but returned with a call to Questions endpoint
+            # overrides: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/OCDS/OCDS_Requirements_Ext.yaml#/components/schemas/RequirementGroup
+            type: object
+            properties:
+              id:
+                title: Identifier
+                description: 'The identifier for this question group. It must be unique and cannot change within the Open Contracting Process it is part of (defined by a single ocid). See the [identifier guidance](http://standard.open-contracting.org/latest/en/schema/identifiers/) for further details.'
+                type: string
+                minLength: 1
+                readOnly: true
+              description: 
+                title: Description
+                description: A description of this question group.
+                nullable: true
+                type: string
+                minLength: 1                
        
  
     Question:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3814,6 +3814,10 @@ components:
             mandatory:
               description: Defines if the user must answer the question to proceed.
               type: boolean
+            requirements:
+              type: array
+              items:
+                $ref: '#/components/schemas/Question'
         OCDS:
             # overrides: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/OCDS/OCDS_Requirements_Ext.yaml#/components/schemas/RequirementGroup
             type: object
@@ -4022,16 +4026,6 @@ components:
             type: string  
           audience:
             $ref: '#/components/schemas/DocumentAudienceType'
-
-    BuyerQuestionGroup:
-      allOf:
-        - $ref: '#/components/schemas/QuestionGroup'
-        - type: object
-          properties:
-            requirements:
-              type: array
-              items:
-                $ref: '#/components/schemas/Question'
     
     BuyerQuestionEvalCriteria:
       description: Defines a question that the buyer should answer to create the event along with answers given.
@@ -4046,7 +4040,7 @@ components:
             requirementGroups:
               type: array
               items:
-                $ref: '#/components/schemas/BuyerQuestionGroup'
+                $ref: '#/components/schemas/QuestionGroup'
       
   securitySchemes:
     openID:

--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -3814,10 +3814,6 @@ components:
             mandatory:
               description: Defines if the user must answer the question to proceed.
               type: boolean
-            requirements:
-              type: array
-              items:
-                $ref: '#/components/schemas/Question'
         OCDS:
             # overrides: https://raw.githubusercontent.com/Crown-Commercial-Service/ccs-api-definitions-common/main/OCDS/OCDS_Requirements_Ext.yaml#/components/schemas/RequirementGroup
             type: object
@@ -3833,7 +3829,11 @@ components:
                 description: A description of this question group.
                 nullable: true
                 type: string
-                minLength: 1                
+                minLength: 1  
+              requirements:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Question'
        
  
     Question:


### PR DESCRIPTION
This is a branch from Nick's original PR at https://github.com/Crown-Commercial-Service/ccs-scale-api-definitions/pull/101

It works around the limitations with the Java code generator in dealing with the approach in the original PR.

The approach here is quite simple - just extends the original objects directly to build a tree structure (the other changes in QuestionGroup are from Nick's original PR). Extending the original objects has no impact on the existing endpoints as the children are not populated - so never appear (e.g. retrieving a Criterion Group will now show the Question children).

However, if this approach is not desired and the preference is not to change these schemas - it's pretty straightforward to add some new wrapper schemas. Just thought I'd start with the simpler, more lightweight approach. Happy to change tho!
