### PR TITLE
Validate journey states array length

### DIFF
--- a/journeys/journeys-service.yaml
+++ b/journeys/journeys-service.yaml
@@ -146,6 +146,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JourneyStepState'
+          minItems: 1
 
     JourneyStepState:
       type: object


### PR DESCRIPTION
Tested in the service by pointing at this branch and the validation on the array length kicks in as expected, returning a `400` if the `states` array is missing or empty.  Could set `maxItems` too if we wish.. but not sure what a sensible value would be.