### PR TITLE
SCAT-3231 - added option-id

### DIFF
--- a/capabilities/capability-service.yaml
+++ b/capabilities/capability-service.yaml
@@ -329,6 +329,8 @@ components:
           items:
             type: object
             properties:
+              option-id:
+                $ref: '#/components/schemas/RequirementId'
               name:
                 type: string
                 example: data


### PR DESCRIPTION
Added `option-id` to response from Get Dimensions endpoint - users of the API can use that to pass in as `requirement-id` in subsequent calls.

Discussions with Nick as to what it should be called - decided on this just to get something in that was functional.