### PR TITLE
Tidy up of Capability Assessment in response to testers comments

### DIFF
--- a/capabilities/capability-service.yaml
+++ b/capabilities/capability-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   title: "SCALE Capability Service"
-  version: v0.0.1
+  version: v0.0.2
   description: This API allows UI's to Query Capabilities.
 #  PLACEHOLDERs - to be uncommented when implemented
   termsOfService: "http://api.crowncommercial.gov.uk/terms/"

--- a/capabilities/capability-service.yaml
+++ b/capabilities/capability-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   title: "SCALE Capability Service"
-  version: v0.0.1
+  version: v0.0.2
   description: This API allows UI's to Query Capabilities.
 #  PLACEHOLDERs - to be uncommented when implemented
   termsOfService: "http://api.crowncommercial.gov.uk/terms/"
@@ -238,7 +238,6 @@ components:
       type: integer
       description: Dimension ID provided within the capability definition .
       example: 1
-      readOnly: true
     AssessmentId:
       type: integer
       description: Assessment ID provided when a new assessment is created.
@@ -248,7 +247,6 @@ components:
       type: integer
       description: ID provided when a new requirement is added from the options provided in a dimension.
       example: 1
-      readOnly: true
     CriterionId:
       type: string
       description: Value ID provided within the capability definition within a dimension .
@@ -288,8 +286,10 @@ components:
         name:
           type: string
           example: Resource Profile (SC)
+          readOnly: true
         type:
           type: string
+          readOnly: true
             
     DimensionDefinition:
       allOf:
@@ -368,18 +368,20 @@ components:
                 $ref: '#/components/schemas/Requirement'
             
     Requirement:
-      allOf:
-        - $ref: '#/components/schemas/DimensionOption'
-        - type: object
-          properties:
-            requirement-id:
-              $ref: '#/components/schemas/RequirementId'
-            weighting:
-              $ref: '#/components/schemas/Percentage'
-            values:
-              type: array
-              items:
-                $ref: '#/components/schemas/Criterion'
+        type: object
+        properties:
+          requirement-id:
+            $ref: '#/components/schemas/RequirementId'
+          name:
+            type: string
+            example: Data Analyst
+            readOnly: true
+          weighting:
+            $ref: '#/components/schemas/Percentage'
+          values:
+            type: array
+            items:
+              $ref: '#/components/schemas/Criterion'
                 
     CriterionDefinition:
       type: object

--- a/capabilities/capability-service.yaml
+++ b/capabilities/capability-service.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.1"
 info:
   title: "SCALE Capability Service"
-  version: v0.0.2
+  version: v0.0.1
   description: This API allows UI's to Query Capabilities.
 #  PLACEHOLDERs - to be uncommented when implemented
   termsOfService: "http://api.crowncommercial.gov.uk/terms/"
@@ -277,6 +277,9 @@ components:
           $ref: '#/components/schemas/AssessmentId'
         external-tool-id:
           $ref: '#/components/schemas/ExternalToolId'
+        status:
+          type: string
+          example: ACTIVE
 
     Dimension:
       type: object

--- a/capabilities/capability-service.yaml
+++ b/capabilities/capability-service.yaml
@@ -324,11 +324,12 @@ components:
     DimensionOption:
       type: object
       properties:
-        option-id:
+        requirement-id:
           $ref: '#/components/schemas/RequirementId'
         name:
           type: string
           example: Data Analyst
+          readOnly: true
         groups:
           type: array
           items:
@@ -371,20 +372,16 @@ components:
                 $ref: '#/components/schemas/Requirement'
             
     Requirement:
-        type: object
-        properties:
-          requirement-id:
-            $ref: '#/components/schemas/RequirementId'
-          name:
-            type: string
-            example: Data Analyst
-            readOnly: true
-          weighting:
-            $ref: '#/components/schemas/Percentage'
-          values:
-            type: array
-            items:
-              $ref: '#/components/schemas/Criterion'
+      allOf:
+        - $ref: '#/components/schemas/DimensionOption'
+        - type: object
+          properties:
+            weighting:
+              $ref: '#/components/schemas/Percentage'
+            values:
+              type: array
+              items:
+                $ref: '#/components/schemas/Criterion'
                 
     CriterionDefinition:
       type: object


### PR DESCRIPTION
Small tidy up based on feedback from Sabarish. 

Removed `readOnly=true` from DimensionId and RequirementId as these were not appearing in the examples for POST/PUT requests.

Added `readOnly=true` to name and type - as they are not required to be sent in requests (as we have IDs) - only to be viewed in responses.

Modified `Requirement` slightly - as it was a superset of `DimensionOption`- since adding `option-id` to that we now had both `option-id` and `requirement-id` - which made no sense. Could rationalise on `requirement-id` for both - but for now left it the API is being used (but we could change that if we were in agreement). For now removed `DimensionOption` and just added a `name` explicitly. Means also lose values/groups - but don't think they are really necessary in a Requirement.

Also added `status` to `Get Assessments` (bugfix SCAT-4158)