### PR TITLE
Add missing FC qstn rel type PercentageGroup

### DIFF
--- a/cat/CaT-service.yaml
+++ b/cat/CaT-service.yaml
@@ -4578,8 +4578,7 @@ components:
         - Outside
         - Alternative
         - MultiAnswerGroup
-        
-  
+        - PercentageGroup
 
     ResponseSummary:
       description: 


### PR DESCRIPTION
To match the use of this in the FC template: https://github.com/Crown-Commercial-Service/ccs-scale-db-scripts-data/pull/97/files